### PR TITLE
v0.0.3

### DIFF
--- a/mangadex_downloader/__init__.py
+++ b/mangadex_downloader/__init__.py
@@ -139,7 +139,9 @@ class Mangadex:
         
 
     def download(self, *urls: str, use_secondary_server=False):
-        pass
+        """Download all mangas"""
+        for url in urls:
+            self.extract_info(url, True, use_secondary_server)
 
     def extract_info(
         self,
@@ -147,6 +149,7 @@ class Mangadex:
         download=True,
         use_secondary_server=False
     ):
+        """Fetch manga information"""
         fetch = MangadexFetcher(url, self.lang)
         self._logger_info('Fetching "%s"' % (url))
         data = fetch.get()

--- a/mangadex_downloader/constants.py
+++ b/mangadex_downloader/constants.py
@@ -52,11 +52,16 @@ class MangaData:
                 groups[chap['chapter']] = chap
         return [groups[i] for i in groups.keys()]
             
+    def _get_total_chapters(self):
+        if 'Oneshot' in self.genres:
+            return 1
+        else:
+            return int(max([float(i['chapter']) for i in self.chapters]))
 
     def __repr__(self):
         return '<MangaData title="%s" chapters=%s language=%s>' %(
             self.title,
-            int(max([float(i['chapter']) for i in self.chapters])),
+            self._get_total_chapters(),
             self.language
         )
 

--- a/mangadex_downloader/fetcher.py
+++ b/mangadex_downloader/fetcher.py
@@ -57,7 +57,6 @@ class MangadexFetcher:
         num = 1
         results = []
         while True:
-            print(self._get_url() + str(num))
             r = requests.get(self._get_url() + str(num))
             if 'Too many hits detected from ' in r.text:
                 raise Exception('Your ip is banned from mangadex')

--- a/mangadex_downloader/parser.py
+++ b/mangadex_downloader/parser.py
@@ -134,7 +134,6 @@ def get_absolute_url(body_string: str):
     parser = BeautifulSoup(body_string, 'html.parser')
     for link_elements in parser.find_all('link'):
         # aiming for canonical link
-        print(link_elements)
         try:
             rel = link_elements.attrs['rel']
             href = link_elements.attrs['href']

--- a/mangadex_downloader/parser.py
+++ b/mangadex_downloader/parser.py
@@ -128,3 +128,21 @@ def parse_chapters_info(json_data: str):
         infos.append(info)
         num += 1
     return [MangaChapterData(i) for i in infos]
+
+def get_absolute_url(body_string: str):
+    """Get absolute manga mangadex url"""
+    parser = BeautifulSoup(body_string, 'html.parser')
+    for link_elements in parser.find_all('link'):
+        # aiming for canonical link
+        print(link_elements)
+        try:
+            rel = link_elements.attrs['rel']
+            href = link_elements.attrs['href']
+        except KeyError:
+            continue
+        else:
+            if 'canonical' in rel:
+                return href
+            else:
+                continue
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import pathlib
 from setuptools import setup
 import sys
 
-__VERSION__ = 'v0.0.2'
+__VERSION__ = 'v0.0.3'
 
 HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
@@ -11,7 +11,7 @@ setup(
   name = 'mangadex-downloader',         
   packages = ['mangadex_downloader'],   
   version = __VERSION__,
-  license='MIT',     
+  license='The Unlicense',     
   description = 'Download manga from Mangadex through Python',
   long_description= README,
   long_description_content_type= 'text/markdown',


### PR DESCRIPTION
TO-DO

Bugs fix
- [x] given url doesn't have title in url causing useless loop request. For example `https://mangadex.org/title/22581` is causing useless loop request because given url doesn't have title in url and `https://mangadex.org/title/22581/saguri-chan-tankentai` is not causing anything because given url have title in url
- [x] `MangaData.__repr__()` raise error for `oneshot` genre manga

Enchantment
- [x] Add `output_folder` in Mangadex class arguments for choose the path in which store the downloaded mangas #1
- [x] add functional `Mangadex.download()`