### PR TITLE
get_mark_image(): Fallback to default font if Arial font is not found

### DIFF
--- a/mangadex_downloader/format/comic_book.py
+++ b/mangadex_downloader/format/comic_book.py
@@ -212,7 +212,7 @@ class ComicBookArchiveVolume(BaseFormat):
                     write_start_image = True
                 
                 if write_start_image:
-                    img = get_mark_image(chap_class)
+                    img = get_mark_image(chap_class, ignore_font=True)
                     fp = io.BytesIO()
                     img.save(fp, 'png')
                     job = lambda: volume_zip.writestr(img_name, fp.getvalue())
@@ -366,7 +366,7 @@ class ComicBookArchiveSingle(BaseFormat):
                 write_start_image = True
             
             if write_start_image:
-                img = get_mark_image(chap_class)
+                img = get_mark_image(chap_class, ignore_font=True)
                 fp = io.BytesIO()
                 img.save(fp, 'png')
                 job = lambda: manga_zip.writestr(img_name, fp.getvalue())

--- a/mangadex_downloader/format/comic_book.py
+++ b/mangadex_downloader/format/comic_book.py
@@ -212,7 +212,7 @@ class ComicBookArchiveVolume(BaseFormat):
                     write_start_image = True
                 
                 if write_start_image:
-                    img = get_mark_image(chap_class, ignore_font=True)
+                    img = get_mark_image(chap_class)
                     fp = io.BytesIO()
                     img.save(fp, 'png')
                     job = lambda: volume_zip.writestr(img_name, fp.getvalue())
@@ -366,7 +366,7 @@ class ComicBookArchiveSingle(BaseFormat):
                 write_start_image = True
             
             if write_start_image:
-                img = get_mark_image(chap_class, ignore_font=True)
+                img = get_mark_image(chap_class)
                 fp = io.BytesIO()
                 img.save(fp, 'png')
                 job = lambda: manga_zip.writestr(img_name, fp.getvalue())

--- a/mangadex_downloader/format/raw.py
+++ b/mangadex_downloader/format/raw.py
@@ -169,7 +169,7 @@ class RawVolume(BaseFormat):
                 # Insert "start of the chapter" image
                 img_name = count.get() + '.png'
                 img_path = chapter_path / img_name
-                img = get_mark_image(chap_class, ignore_font=True)
+                img = get_mark_image(chap_class)
                 img.save(img_path, 'png')
 
                 count.increase()
@@ -292,7 +292,7 @@ class RawSingle(BaseFormat):
             # Insert "start of the chapter" image
             img_name = count.get() + '.png'
             img_path = path / img_name
-            img = get_mark_image(chap_class, ignore_font=True)
+            img = get_mark_image(chap_class)
             img.save(img_path, 'png')
 
             count.increase()

--- a/mangadex_downloader/format/raw.py
+++ b/mangadex_downloader/format/raw.py
@@ -169,7 +169,7 @@ class RawVolume(BaseFormat):
                 # Insert "start of the chapter" image
                 img_name = count.get() + '.png'
                 img_path = chapter_path / img_name
-                img = get_mark_image(chap_class)
+                img = get_mark_image(chap_class, ignore_font=True)
                 img.save(img_path, 'png')
 
                 count.increase()
@@ -292,7 +292,7 @@ class RawSingle(BaseFormat):
             # Insert "start of the chapter" image
             img_name = count.get() + '.png'
             img_path = path / img_name
-            img = get_mark_image(chap_class)
+            img = get_mark_image(chap_class, ignore_font=True)
             img.save(img_path, 'png')
 
             count.increase()

--- a/mangadex_downloader/format/utils.py
+++ b/mangadex_downloader/format/utils.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+from shutil import ignore_patterns
 import threading
 import time
 import textwrap
@@ -57,7 +58,7 @@ def load_font():
 
     raise FontNotFound(f'fonts {list_font_family} are not found')
 
-def get_mark_image(chapter):
+def get_mark_image(chapter,ignore_font=False):
     text = ""
 
     # Current chapter (Volume. n Chapter. n)
@@ -75,7 +76,13 @@ def get_mark_image(chapter):
 
     text +=  f"Translated by: {chapter.groups_name}"
 
-    font = load_font()
+    font = None # avoid unbounded variable warning
+    try:
+        font = load_font()
+    except FontNotFound as e:
+        if not ignore_font:
+            raise e
+
     img = Image.new(image_mode, image_size, rgb_white)
     draw = ImageDraw.Draw(img, image_mode)
     draw.multiline_text(text_pos, text, rgb_black, font, align='center')


### PR DESCRIPTION
Hi, thanks for the very optimized tool. There's this problem I have on Linux where font `Ariel.ttf` ( Microsoft's font ) is not found on Linux system.

I believe, at least for Raw and CBZ format, the fonts should not matter when we are downloading raw png image. So I propose we add an optional flag to enable ignore `FontNotFound` exception, it is `False` by default 