### PR TITLE
--start-volume & --end-volume functionality addition

### DIFF
--- a/mangadex_downloader/chapter.py
+++ b/mangadex_downloader/chapter.py
@@ -482,6 +482,14 @@ class IteratorChapter:
 
         is_number = isinstance(num_chap, float)
         is_vol_number = isinstance(num_vol, float)
+        
+        if is_vol_number and num_vol > 0.0:
+            if self.start_volume is not None and not (num_vol >= self.start_volume):
+                log.debug(f"Ignoring chapter in volume {num_vol}, because volume {num_vol} is in ignored list")
+                return False
+            if self.end_volume is not None and not (num_vol <= self.end_volume):
+                log.debug(f"Ignoring chapter in volume {num_vol}, because volume {num_vol} is in ignored list")
+                return False
 
         # There is a chance that "Chapter 0" is Oneshot or prologue
         # We need to verify that is valid oneshot chapter
@@ -496,13 +504,6 @@ class IteratorChapter:
                 log.debug(f"Ignoring chapter {num_chap}, because chapter {num_chap} is in ignored list")
                 return False
 
-        if is_vol_number and num_vol > 0.0:
-            if self.start_volume is not None and not (num_vol >= self.start_volume):
-                log.debug(f"Ignoring chapter in volume {num_vol}, because volume {num_vol} is in ignored list")
-                return False
-            if self.end_volume is not None and not (num_vol <= self.end_volume):
-                log.debug(f"Ignoring chapter in volume {num_vol}, because volume {num_vol} is in ignored list")
-                return False
 
         if chap.oneshot and self.no_oneshot and not self.all_group:
             log.debug("Ignoring oneshot chapter since it's in ignored list")

--- a/mangadex_downloader/chapter.py
+++ b/mangadex_downloader/chapter.py
@@ -372,6 +372,8 @@ class IteratorChapter:
         no_oneshot=None,
         groups=None,
         _range=None,
+        start_volume=None,
+        end_volume=None,
         **kwargs
     ):
 
@@ -380,7 +382,9 @@ class IteratorChapter:
             end_chapter or
             start_page or
             end_page or
-            no_oneshot
+            no_oneshot or
+            start_volume or
+            end_volume
         )
 
         if _range and legacy_range:
@@ -395,6 +399,8 @@ class IteratorChapter:
         self.start_page = start_page
         self.end_page = end_page
         self.no_oneshot = no_oneshot
+        self.start_volume = start_volume
+        self.end_volume = end_volume
         self.groups = None
         self.all_group = False
         self.legacy_range = legacy_range
@@ -456,6 +462,7 @@ class IteratorChapter:
 
     def _check_range_chapter_legacy(self, chap):
         num_chap = chap.chapter
+        num_vol = chap.volume
         if num_chap != 'none':
             try:
                 num_chap = float(num_chap)
@@ -464,8 +471,17 @@ class IteratorChapter:
             except TypeError:
                 # null value
                 pass
+        if num_vol != 'none':
+            try:
+                num_vol = float(num_vol)
+            except ValueError:
+                pass
+            except TypeError:
+                # null value
+                pass
 
         is_number = isinstance(num_chap, float)
+        is_vol_number = isinstance(num_vol, float)
 
         # There is a chance that "Chapter 0" is Oneshot or prologue
         # We need to verify that is valid oneshot chapter
@@ -480,6 +496,14 @@ class IteratorChapter:
                 log.debug(f"Ignoring chapter {num_chap}, because chapter {num_chap} is in ignored list")
                 return False
 
+        if is_vol_number and num_vol > 0.0:
+            if self.start_volume is not None and not (num_vol >= self.start_volume):
+                log.debug(f"Ignoring chapter in volume {num_vol}, because volume {num_vol} is in ignored list")
+                return False
+            if self.end_volume is not None and not (num_vol <= self.end_volume):
+                log.debug(f"Ignoring chapter in volume {num_vol}, because volume {num_vol} is in ignored list")
+                return False
+
         if chap.oneshot and self.no_oneshot and not self.all_group:
             log.debug("Ignoring oneshot chapter since it's in ignored list")
             return False
@@ -491,7 +515,10 @@ class IteratorChapter:
                 log.debug(f"Ignoring chapter {num_chap}, because chapter {num_chap} is in ignored list")
                 return False
 
+
+
         return True
+
 
     def _check_range_chapter(self, chap):
         if self.legacy_range:

--- a/mangadex_downloader/cli/args_parser.py
+++ b/mangadex_downloader/cli/args_parser.py
@@ -198,6 +198,23 @@ def get_args(argv):
         default=config.volume_cover_language,
     )
 
+    # Volume related
+    vol_group = parser.add_argument_group('Volume')
+    vol_group.add_argument(
+        '--start-volume',
+        '-sv',
+        type=float,
+        help='Start download chapter from given volume number',
+        metavar='VOLUME'
+    )
+    vol_group.add_argument(
+        '--end-volume',
+        '-ev',
+        type=float,
+        help='Stop download chapter from given volume number',
+        metavar='VOLUME'
+    )
+
     # Chapter related
     chap_group = parser.add_argument_group('Chapter')
     chap_group.add_argument(

--- a/mangadex_downloader/cli/url.py
+++ b/mangadex_downloader/cli/url.py
@@ -58,6 +58,10 @@ def download_manga(url, args, legacy=False):
         if args.start_chapter > args.end_chapter:
             raise MangaDexException("--start-chapter cannot be more than --end-chapter")
 
+    if args.start_volume is not None and args.end_volume is not None:
+        if args.start_volume > args.end_volume:
+            raise MangaDexException("--start-volume cannot be more than --end-volume")
+
     if args.start_page is not None and args.end_page is not None:
         if args.start_page > args.end_page:
             raise MangaDexException("--start-page cannot be more than --end-page")
@@ -68,7 +72,9 @@ def download_manga(url, args, legacy=False):
         'end_chapter': '--end-chapter',
         'start_page': '--start-page',
         'end_page': '--end-page',
-        'no_oneshot_chapter': '--no-oneshot-chapter'
+        'no_oneshot_chapter': '--no-oneshot-chapter',
+        'start_volume': '--start-volume',
+        'end_volume': '--end-volume'
     }
     for name, arg in range_forbidden_args.items():
         value = getattr(args, name)
@@ -86,6 +92,8 @@ def download_manga(url, args, legacy=False):
         args.start_page,
         args.end_page,
         args.no_oneshot_chapter,
+        args.start_volume,
+        args.end_volume,
         args.use_alt_details,
         args.group,
         args.range,
@@ -129,6 +137,10 @@ def download_list(url, args):
         _error_list('--start-page')
     elif args.end_page:
         _error_list('--end-page')
+    elif args.start_volume:
+        _error_list('--start-volume')
+    elif args.end_volume:
+        _error_list('--end-volume')
     elif args.range:
         _error_list('--range')
 

--- a/mangadex_downloader/main.py
+++ b/mangadex_downloader/main.py
@@ -52,6 +52,8 @@ def download(
     start_page=None,
     end_page=None,
     no_oneshot_chapter=False,
+    start_volume=False,
+    end_volume=False,
     use_alt_details=False,
     groups=None,
     _range=None,
@@ -118,6 +120,8 @@ def download(
             "start_page": start_page,
             "end_page": end_page,
             "no_oneshot": no_oneshot_chapter,
+            "start_volume": start_volume,
+            "end_volume": end_volume,
             "groups": groups,
             "_range": _range,
         }


### PR DESCRIPTION
While development is being made on the --range CLI arg, I modified chapter.py, args_parser.py, url.py, and main.py to add the cli args --start-volume and --end-volume, mirroring the --start-chapter and --end-chapter args.