### PR TITLE
Feature/chapter naming format

### DIFF
--- a/mangadex_downloader/chapter.py
+++ b/mangadex_downloader/chapter.py
@@ -39,7 +39,7 @@ from .network import Net, base_url
 from .errors import ChapterNotFound, GroupNotFound, UserNotFound
 from .group import Group
 from .config import config, env
-from .utils import convert_int_or_float, get_local_attr
+from .utils import convert_int_or_float, get_local_attr, get_chapter_naming_format_regex_pattern
 from .progress_bar import progress_bar_manager as pbm
 # from . import range as range_mod # range_mod stands for "range module"
 
@@ -315,7 +315,7 @@ class Chapter:
 
     def _apply_name_format(self, format_string: str):
         format = format_string
-        pattern = "(\{\{(?:[A-Z])(?::?[0-9]*)\}\})"
+        pattern = get_chapter_naming_format_regex_pattern()
         matches = re.split(pattern, format)
 
         for idx, match in enumerate(matches):

--- a/mangadex_downloader/cli/args_parser.py
+++ b/mangadex_downloader/cli/args_parser.py
@@ -290,7 +290,8 @@ def get_args(argv):
             "{{T}} is chapter title,\n"\
             "{{G}} is scanlation group name.\n"\
             "For example: 'Chapter {{C:2}} Vol. {{V}} - {{T}} [{{G}}]' will produce filename called 'Chapter 09 Vol. 1 - MangaTitle [TranslationGroup]'\n"\
-            "This bypasses --use-chapter-title and --no-group-name both in arguments and in the config file."
+            "This bypasses --use-chapter-title and --no-group-name both in arguments and in the config file.",
+        default=''
     )
 
 

--- a/mangadex_downloader/cli/args_parser.py
+++ b/mangadex_downloader/cli/args_parser.py
@@ -280,6 +280,19 @@ def get_args(argv):
              "NOTE: Volume cover will be not created in chapter (cbz, pdf, raw, etc) and single formats)",
         default=config.use_volume_cover
     )
+    chap_group.add_argument(
+        "--chapter-naming-format",
+        "-cnf",
+        help="Output format of the chapter filename, where:\n"\
+            "{{M}} is manga title, "\
+            "{{C}} is chapter number (use {{C:x}} when you want to pad the number with zeroes - e.g. {{C:3}} produces 001 for chapter no. 1),\n"\
+            "{{V}} is volume number (use {{V:x}} when you want to pad the number with zeroes - e.g. {{V:2}} produces 02 for volume no. 2),\n"\
+            "{{T}} is chapter title,\n"\
+            "{{G}} is scanlation group name.\n"\
+            "For example: 'Chapter {{C:2}} Vol. {{V}} - {{T}} [{{G}}]' will produce filename called 'Chapter 09 Vol. 1 - MangaTitle [TranslationGroup]'\n"\
+            "This bypasses --use-chapter-title and --no-group-name both in arguments and in the config file."
+    )
+
 
     # Chapter page related
     chap_page_group = parser.add_argument_group("Chapter Page")

--- a/mangadex_downloader/config/config.py
+++ b/mangadex_downloader/config/config.py
@@ -137,8 +137,7 @@ class _Config:
         ],
         "chapter_naming_format": [
             '',
-            #TODO ASAP: validate this somehow
-            dummy_validator
+            validate_chapter_naming_format_syntax
         ]
     }
     default_conf = {

--- a/mangadex_downloader/config/config.py
+++ b/mangadex_downloader/config/config.py
@@ -135,6 +135,11 @@ class _Config:
             "default",
             validate_progress_bar_layout
         ],
+        "chapter_naming_format": [
+            '',
+            #TODO ASAP: validate this somehow
+            dummy_validator
+        ]
     }
     default_conf = {
         x: y for x, (y, _) in confs.items()

--- a/mangadex_downloader/config/utils.py
+++ b/mangadex_downloader/config/utils.py
@@ -24,6 +24,7 @@ import logging
 import zipfile
 import os
 import typing
+import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 from requests_doh import get_all_dns_provider, add_dns_provider
@@ -31,7 +32,7 @@ from requests_doh import get_all_dns_provider, add_dns_provider
 from .. import format as fmt
 from ..errors import MangaDexException, InvalidURL
 from ..language import get_language
-from ..utils import validate_url, get_key_value
+from ..utils import validate_url, get_key_value, get_chapter_naming_format_regex_pattern
 from ..progress_bar import progress_bar_manager
 
 __all__ = (
@@ -40,7 +41,7 @@ __all__ = (
     "validate_int", "validate_tag", "validate_blacklist",
     "validate_sort_by", "validate_http_retries", "validate_download_mode",
     "validate_doh_provider", "validate_log_level", "validate_progress_bar_layout",
-    "validate_stacked_progress_bar_order",
+    "validate_stacked_progress_bar_order", "validate_chapter_naming_format_syntax",
     "load_env", "LazyLoadEnv", "ConfigTypeError"
 )
 
@@ -280,3 +281,10 @@ def validate_stacked_progress_bar_order(val):
 
     progress_bar_manager.set_types_order(*values)
     return values
+
+def validate_chapter_naming_format_syntax(val : str):
+    pattern = get_chapter_naming_format_regex_pattern()
+    matches = re.findall(pattern, val)
+    if len(matches) <= 0:
+        raise ConfigTypeError(f"'{val}' does not contain any formatting syntax")
+    return val

--- a/mangadex_downloader/utils.py
+++ b/mangadex_downloader/utils.py
@@ -316,3 +316,6 @@ def get_key_value(text, sep='='):
     key = splitted[0].lower()
     value = "".join(splitted[1:])
     return key, value
+
+def get_chapter_naming_format_regex_pattern() -> str:
+    return "(\{\{(?:[A-Z])(?::?[0-9]*)\}\})"


### PR DESCRIPTION
Added --chapter-naming-format argument with simple syntax to allow specifying downloaded chapter naming pattern.

For example:
`"--chapter-naming-format" "{{M}} Vol {{V:2}} Ch. {{C:3}} - {{T}} [{{G}}]"` will produce filenames with following pattern:
`Ijiranaide, Nagatoro-san Vol 11 Ch. 080 - ...If You Win Even a Single Match, Senpai [anonymous]`