### PR TITLE
Append vol. or ch. name to EPUB title

### DIFF
--- a/mangadex_downloader/format/epub.py
+++ b/mangadex_downloader/format/epub.py
@@ -59,7 +59,7 @@ class EpubPlugin:
     def __init__(self, manga, lang, file_id = ""):
         self.manga = manga
         self.id = manga.id
-        self.title = f"{manga.title} - {file_id}" if file_id else manga.title
+        self.title = f"{manga.title}, {file_id}" if file_id else manga.title
         self.lang = lang
 
         self._chapter_pos = 0


### PR DESCRIPTION
A proposed solution to #149. This PR only change `dc:title` in EPUB opf, filenames remain unchanged.

## Preview

1.  is generated with `--save-as "epub"`,
2.  is generated with `--save-as "epub-volume"`. 

The book title of `epub-single` is not changed.

![image](https://github.com/user-attachments/assets/39059a61-2408-48cd-b3c1-1d78beffe2a3)

EDIT: I changed separator to comma (`Akatsuki no Yona, Vol. 1`) in order to match the format on Amazon Kindle store
