### PR TITLE
fix comic book title metadata

### DIFF
--- a/mangadex_downloader/format/comic_book.py
+++ b/mangadex_downloader/format/comic_book.py
@@ -105,7 +105,7 @@ def generate_Comicinfo(manga, total_pages, chapter=None, volume=None):
             xml_num.text = str(chapter.chapter)
 
         xml_title = ET.SubElement(xml_root, "Title")
-        xml_title.text = chapter.name
+        xml_title.text = chapter.title
 
         xml_si = ET.SubElement(xml_root, "ScanInformation")
         xml_si.text = chapter.groups_name


### PR DESCRIPTION
the current implementation of the ComicInfo.xml generation erroneously retrieves the `chapter.name` attribute for the `<Title>` field, rather than `chapter.title` which corresponds to the actual title of a given chapter. given this, the title of any chapter downloaded as .cbz will always be `Volume #, Chapter #`, which is entirely redundant with the `<Volume>` and `<Number>` fields, respectively