### PR TITLE
Add publication year to path and filename placeholders, and info files.

### DIFF
--- a/docs/cli_ref/path_placeholders.md
+++ b/docs/cli_ref/path_placeholders.md
@@ -45,6 +45,7 @@ For more information, see below:
 | ----- | ----- | ----- |
 | title | The title of the manga | [string](#string) |
 | id | The unique identifier of manga | [string](#string) |
+| year | The publication year of the manga | [integer](#integer) |
 | alternative_titles | Alternative titles of the manga | [array](#array)[[string](#string)] |
 | description | The description of the manga | [string](#string) |
 | authors | List of authors of the manga separated by comma | [string](#string) |

--- a/mangadex_downloader/format/comic_book.py
+++ b/mangadex_downloader/format/comic_book.py
@@ -46,6 +46,10 @@ def generate_Comicinfo(manga, total_pages, chapter=None, volume=None):
     xml_series = ET.SubElement(xml_root, "Series")
     xml_series.text = manga.title
 
+    # Publication year
+    xml_year = ET.SubElement(xml_root, "Year")
+    xml_year.text = str(manga.year)
+
     # Authors
     if len(manga.authors) > 0:
         author_str = ""

--- a/mangadex_downloader/format/comic_book.py
+++ b/mangadex_downloader/format/comic_book.py
@@ -46,10 +46,6 @@ def generate_Comicinfo(manga, total_pages, chapter=None, volume=None):
     xml_series = ET.SubElement(xml_root, "Series")
     xml_series.text = manga.title
 
-    # Publication year
-    xml_year = ET.SubElement(xml_root, "Year")
-    xml_year.text = str(manga.year)
-
     # Authors
     if len(manga.authors) > 0:
         author_str = ""

--- a/mangadex_downloader/manga.py
+++ b/mangadex_downloader/manga.py
@@ -355,10 +355,11 @@ class MangaInfo:
 
     def write_to_csv(self):
         existing_data = []
-        fieldnames = ["title", "authors", "artists", "description", "tags"]
+        fieldnames = ["title", "year", "authors", "artists", "description", "tags"]
 
         data = {
             "title": self.manga.title,
+            "year": self.manga.year,
             "authors": comma_separated_text(self.manga.authors, use_bracket=False),
             "artists": comma_separated_text(self.manga.artists, use_bracket=False),
             "description": self.manga.description.replace("\n", "\\n").replace(
@@ -398,6 +399,7 @@ class MangaInfo:
 
         data = {
             "title": self.manga.title,
+            "year": self.manga.year,
             "authors": self.manga.authors,
             "artists": self.manga.artists,
             "description": self.manga.description,

--- a/mangadex_downloader/manga.py
+++ b/mangadex_downloader/manga.py
@@ -180,6 +180,11 @@ class Manga:
         return self._attr.get("status").capitalize()
 
     @property
+    def year(self):
+        """:class:`int`: Initial publication year of the manga"""
+        return self._attr.get("year")
+
+    @property
     def content_rating(self):
         """:class:`ContentRating`: Return content rating of the manga"""
         return ContentRating(self._attr.get("contentRating"))

--- a/mangadex_downloader/path/placeholders.py
+++ b/mangadex_downloader/path/placeholders.py
@@ -106,6 +106,7 @@ class Placeholder:
                 "cover": None,
                 "genres": _split_text,
                 "status": None,
+                "year": None,
                 "content_rating": None,
                 "tags": lambda x: _split_text([i.name for i in x]),
             }


### PR DESCRIPTION
Adds half of https://github.com/mansuf/mangadex-downloader/issues/140.

Allows the use of `{manga.year}` as a placeholder in path formatting (`--path`) and filename formatting (`--filename-<format>`).

Also adds the publication year to manga info files (excl. Mihon) and `ComicInfo.xml` files. It is not included in the Mihon format, as a "year" key is not defined in [their schema](https://mihon.app/docs/guides/local-source/advanced#editing-local-series-details). (and I don't know if it would simply be ignored.)

~Feel free to revert the `ComicInfo.xml` changes, since while Kavita [implies](https://wiki.kavitareader.com/guides/metadata/comics) that only using the year means that the year defines the release date of the _series_, the official schema [states](https://anansi-project.github.io/docs/comicinfo/documentation) that the all of the year, month, and day, are used as the release date of the _book_ (i.e., volume, chapter -- whatever the `.cbz` file contains). (the `year` returned by MangaDex is of the _series_.) Waiting for confirmation here: https://github.com/anansi-project/comicinfo/discussions/18~

~Note: This doesn't yet add year metadata to EPUB files.~

Edit: Doesn't currently make sense to add publication year to book file metadata.