### PR TITLE
Add placeholder for a sequential chapter number

### DIFF
--- a/docs/cli_ref/path_placeholders.md
+++ b/docs/cli_ref/path_placeholders.md
@@ -92,7 +92,7 @@ mangadex-dl "url" -f cbz --filename-chapter "{manga.title} Ch. {chapter.chapter}
 
 | attribute | description | type data |
 | ----- | ----- | ----- |
-| chapter | Manga chapter in number from 0 to 1 (You can get `Unknown` if there is no valid chapter number) | [integer](#integer) |
+| chapter | Manga chapter in number from 0 to 1 (You can get `Unknown` if there is no valid chapter number). May be a non-integer value | [string](#string) |
 | volume | Manga volume in number from 0 to 1 (You can get `Unknown` if there is no valid volume number) | [integer](#integer) |
 | title | Chapter title | [string](#string) |
 | pages | Total pages in the chapter | [integer](#integer) |
@@ -100,6 +100,7 @@ mangadex-dl "url" -f cbz --filename-chapter "{manga.title} Ch. {chapter.chapter}
 | name | Full parsed chapter name (ex: `Volume. 69 Chapter. 69`) | [string](#string) |
 | simple_name | Simplified parsed chapter name (ex: `Vol. 69 Ch. 69`) | [string](#string) |
 | groups_name | List of scanlation groups for the chapter separated by `&` (you can get `User - username` if there is no scanlation groups available) | [string](#string) |
+| num | Sequential integer number of the chapter (You can get Unknown if you download a single chapter) | [integer](#integer) |
 
 ## Placeholder objects for `--filename-volume` option
 

--- a/mangadex_downloader/chapter.py
+++ b/mangadex_downloader/chapter.py
@@ -157,6 +157,7 @@ class Chapter:
             data = get_chapter(_id)["data"]
 
         self.id = data["id"]
+        self.num = data.get("num")
         self.attr = data["attributes"]
 
         # Get scanlation groups and manga
@@ -351,7 +352,8 @@ def iter_chapters_feed(manga_id, lang=None):
         if not items:
             break
 
-        for item in items:
+        for i, item in enumerate(items):
+            item["num"] = i + 1
             yield item
 
         offset += len(items)

--- a/mangadex_downloader/path/placeholders.py
+++ b/mangadex_downloader/path/placeholders.py
@@ -112,6 +112,7 @@ class Placeholder:
 
         if chapter:
             attr["Chapter"] = {
+                "num": _get_or_unknown,
                 "chapter": _get_or_unknown,
                 "volume": _get_or_unknown,
                 "title": sanitize_filename,


### PR DESCRIPTION
Chapter numbers can often be fractional, for example 7.5. When saving such chapters, the alphabetical order is violated and such chapters go earlier than the main ones (the file with chapter 7.5 before chapter 7). This patch adds the ability to add a sequential chapter number to the file name to preserve order. For example, template like a that:
--filename-chapter="{chapter.num} {chapter.name}{file_ext}"